### PR TITLE
Refactor Day 1 storage account into module

### DIFF
--- a/Day 1/modules.md
+++ b/Day 1/modules.md
@@ -1,0 +1,84 @@
+# Day 1: Understanding Bicep Modules
+
+## What is a Bicep Module?
+A Bicep module is a reusable subset of Bicep code that encapsulates a specific piece of infrastructure. Modules let you break down complex deployments into smaller, manageable components that can be shared across deployments or composed together in a single template.
+
+## How Modules Are Used
+Modules are declared in a parent Bicep file using the `module` keyword, followed by a symbolic name, the path to the module file, and any parameters the module requires. This approach promotes composition: one template can call multiple modules to provision a full environment. Parameters, outputs, and scopes can be passed between the parent template and the module, making it easy to reuse the same module across environments by simply changing input values.
+
+```bicep
+@description('Name of the storage account (must be globally unique).')
+param storageAccountName string
+
+@description('Azure region where the storage account will be deployed.')
+param location string
+
+@description('SKU for the storage account.')
+param skuName string = 'Standard_LRS'
+
+module storageModule './modules/storageAccountModule.bicep' = {
+  name: 'storageDeployment'
+  params: {
+    storageAccountName: storageAccountName
+    location: location
+    skuName: skuName
+    tags: {
+      environment: 'dev'
+    }
+  }
+}
+
+output storageAccountId string = storageModule.outputs.storageAccountId
+```
+
+## Benefits of Using Modules
+- **Reusability**: Define infrastructure once and reuse it across solutions and teams.
+- **Consistency**: Enforce naming conventions, tags, and policies by centralising common components.
+- **Collaboration**: Teams can contribute improvements to shared modules without affecting parent templates.
+- **Simplified maintenance**: When requirements change, update a single module rather than multiple templates.
+
+## Example: Storage Account Module
+Below is an example of a module file (saved at `modules/storageAccountModule.bicep`) that provisions an Azure Storage Account. The module can be referenced from a parent template (as shown above) and parameterised for different environments.
+
+```bicep
+@description('Name of the storage account (must be globally unique).')
+param storageAccountName string
+
+@description('Azure region where the storage account will be deployed.')
+param location string
+
+@description('SKU for the storage account.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+  'Standard_ZRS'
+  'Premium_LRS'
+])
+param skuName string = 'Standard_LRS'
+
+@description('Kind of storage account to deploy.')
+@allowed([
+  'StorageV2'
+  'FileStorage'
+  'BlockBlobStorage'
+])
+param kind string = 'StorageV2'
+
+@description('Tags to apply to the storage account.')
+param tags object = {}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: skuName
+  }
+  kind: kind
+  tags: tags
+}
+
+output storageAccountId string = storageAccount.id
+```
+
+This module illustrates how you can encapsulate the logic for creating a storage account, leaving the parent template to supply environment-specific values such as the name, SKU, and tags.

--- a/Day 1/modules/storageAccountModule.bicep
+++ b/Day 1/modules/storageAccountModule.bicep
@@ -1,0 +1,38 @@
+@description('Name of the storage account (must be globally unique).')
+param storageAccountName string
+
+@description('Azure region where the storage account will be deployed.')
+param location string
+
+@description('SKU for the storage account.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+  'Standard_ZRS'
+  'Premium_LRS'
+])
+param skuName string = 'Standard_LRS'
+
+@description('Kind of storage account to deploy.')
+@allowed([
+  'StorageV2'
+  'FileStorage'
+  'BlockBlobStorage'
+])
+param kind string = 'StorageV2'
+
+@description('Tags to apply to the storage account.')
+param tags object = {}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: skuName
+  }
+  kind: kind
+  tags: tags
+}
+
+output storageAccountId string = storageAccount.id

--- a/Day 1/storageAccount.bicep
+++ b/Day 1/storageAccount.bicep
@@ -1,0 +1,39 @@
+@description('Name of the storage account (must be globally unique).')
+param storageAccountName string
+
+@description('Azure region where the storage account will be deployed.')
+param location string
+
+@description('SKU for the storage account.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+  'Standard_ZRS'
+  'Premium_LRS'
+])
+param skuName string = 'Standard_LRS'
+
+@description('Kind of storage account to deploy.')
+@allowed([
+  'StorageV2'
+  'FileStorage'
+  'BlockBlobStorage'
+])
+param kind string = 'StorageV2'
+
+@description('Tags to apply to the storage account.')
+param tags object = {}
+
+module storageAccountModule 'modules/storageAccountModule.bicep' = {
+  name: 'day1StorageAccountModule'
+  params: {
+    storageAccountName: storageAccountName
+    location: location
+    skuName: skuName
+    kind: kind
+    tags: tags
+  }
+}
+
+output storageAccountId string = storageAccountModule.outputs.storageAccountId

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # BicepLearning
-
 This repo is for me to learn about Azure Bicep publicly and to demonstrate learning fundamentals and best practices.
+
+## Deploying the Day 1 Storage Account Sample
+1. Ensure you have the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and are logged in:
+   ```bash
+   az login
+   ```
+2. Set the target subscription and resource group (create the resource group if it does not exist):
+   ```bash
+   az account set --subscription <your-subscription-id>
+   az group create --name <resource-group-name> --location <azure-region>
+   ```
+3. Deploy the Day 1 sample, which invokes the storage account module located in `Day 1/modules/storageAccountModule.bicep`:
+   ```bash
+   az deployment group create \
+     --name storageAccountDeployment \
+     --resource-group <resource-group-name> \
+     --template-file "Day 1/storageAccount.bicep" \
+     --parameters storageAccountName=<unique-storage-account-name> \
+                  location=<azure-region> \
+                  skuName=Standard_LRS
+   ```
+4. After the deployment succeeds, the command output includes the storage account resource ID from the module output.


### PR DESCRIPTION
## Summary
- split the Day 1 storage account sample into a parent template and a dedicated module file
- update the Day 1 modules guide to demonstrate wiring the parent to the module output
- clarify the README deployment instructions to highlight the module-based structure

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d2271ebf40832e92b7f3f4f38602e3